### PR TITLE
Fix gender calculation error and intersex gender chances

### DIFF
--- a/Earth/Entity/Human/humanExperience.py
+++ b/Earth/Entity/Human/humanExperience.py
@@ -85,23 +85,26 @@ class humanExperience:
         char["Sex at Birth"] = sex
 
         #Gender
-        g = random.randint(0, 100)
-        if g < 10:
-            if sex == "Male":
-                gender = "Female"
-            elif sex == "Female":
+        if sex == "Intersex":
+            g = random.randint(0, 100)
+            if g < 30:
                 gender = "Male"
-        elif g < 20:
-            gender = "Non-Binary"
+            elif g < 60:
+                gender = "Female"
+            else:
+                gender = "Non-Binary"
         else:
-            gender = sex
-            if sex == "Intersex":
-                if g < 30:
-                    gender = "Male"
-                elif g < 60:
+            g = random.randint(0, 100)
+            if g < 10:
+                if sex == "Male":
                     gender = "Female"
-                else: 
-                    gender = "Non-Binary"
+                elif sex == "Female":
+                    gender = "Male"
+            elif g < 20:
+                gender = "Non-Binary"
+            else:
+                gender = sex
+
         #write Gender
         char["Gender"] = gender
         char["Gender Conformity"] = str(random.randint(0,100)) + "/100"


### PR DESCRIPTION
The commit changes the gender calculation to avoid an error when a character is intersex and the gender assignment random int is < 10 which result in the character having no gender variable assigned.

Also, it ensures that the gender assigned to intersex characters is more evenly distributed as currently an intersex character is male only if g < 30 but it needs to be > 20 to begin with which means the chance to be intersex and male is lower than other options.